### PR TITLE
updated spqlios lib pointer and fix for normalize_base2k_tmp_bytes

### DIFF
--- a/04-automorphisms/automorphism.cpp
+++ b/04-automorphisms/automorphism.cpp
@@ -8,7 +8,7 @@
 void apply_automorphism_on_plaintext(const MODULE* module, int64_t p, uint64_t k,  //
                                      int64_t* res_mu,                              //
                                      const int64_t* in_mu) {
-  uint8_t* tmp_space = get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module, message_limbs, message_limbs));
+  uint8_t* tmp_space = get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module));
   vec_znx_automorphism(module, p,                 //
                        res_mu, message_limbs, N,  //
                        in_mu, message_limbs, N);
@@ -65,7 +65,7 @@ void apply_automorphism(const MODULE* module, int64_t p, uint64_t k,  //
   VEC_ZNX_BIG* temp_big = (VEC_ZNX_BIG*)temp_dft;  // alias
   uint8_t* tmp_space = get_tmp_space(std::max(
                                          vmp_apply_dft_to_dft_tmp_bytes(module, autom_ncols, ell, autom_nrows, autom_ncols),
-                                         vec_znx_big_normalize_base2k_tmp_bytes(module, ell, ell)));
+                                         vec_znx_big_normalize_base2k_tmp_bytes(module)));
   vec_znx_dft(module, //
               autom_a_dft, ell, //
               autom_a.data(), ell, N);

--- a/04-automorphisms/backend.cpp
+++ b/04-automorphisms/backend.cpp
@@ -12,7 +12,7 @@ void rlwe_encrypt(const MODULE* module, uint64_t k,         //
   std::vector<Int64VecN> tmp(nlimbs);
   VEC_ZNX_DFT* tmp_dft = vec_znx_dft_alloc(module, nlimbs);
   VEC_ZNX_BIG* tmp_big = (VEC_ZNX_BIG*)tmp_dft;
-  uint64_t tmp_bytes = vec_znx_big_normalize_base2k_tmp_bytes(module, nlimbs, nlimbs);
+  uint64_t tmp_bytes = vec_znx_big_normalize_base2k_tmp_bytes(module);
 
   // randomize a completely
   for (uint64_t i = 0; i < nlimbs; ++i) {
@@ -52,7 +52,7 @@ double rlwe_decrypt(const MODULE* module, uint64_t k,                     //
   std::vector<double> rem(N);
   VEC_ZNX_DFT* tmp_dft = vec_znx_dft_alloc(module, nlimbs);
   VEC_ZNX_BIG* tmp_big = (VEC_ZNX_BIG*)tmp_dft;
-  uint64_t tmp_bytes = vec_znx_big_normalize_base2k_tmp_bytes(module, nlimbs, nlimbs);
+  uint64_t tmp_bytes = vec_znx_big_normalize_base2k_tmp_bytes(module);
 
   // compute b - a.s
   svp_apply_dft(module,           //

--- a/05-onionpir/onionpir.cpp
+++ b/05-onionpir/onionpir.cpp
@@ -106,7 +106,7 @@ void onionpir_rlwe_trivial_encrypt_inplace(const MODULE* module,               /
     vec_znx_normalize_base2k(module, ONIONPIR_K,            //
                              c[0], a_size, 2 * ONIONPIR_N,  //
                              c[0], a_size, 2 * ONIONPIR_N,  //
-                             get_tmp_space(vec_znx_big_normalize_base2k_tmp_bytes(module, a_size, a_size)));
+                             get_tmp_space(vec_znx_big_normalize_base2k_tmp_bytes(module)));
   }
 }
 
@@ -256,7 +256,7 @@ EXPORT void onionpir_online_phase1(const MODULE* module,  // N
       ONIONPIR_query1exp_ncols,                       // res
       ONIONPIR_query1exp_nrows,                       // in
       ONIONPIR_query1exp_nrows, ONIONPIR_query1exp_ncols);
-  uint64_t t2 = vec_znx_big_range_normalize_base2k_tmp_bytes(module, result_a_size, ONIONPIR_query1exp_ncols);
+  uint64_t t2 = vec_znx_big_range_normalize_base2k_tmp_bytes(module);
   if (t2 > tmp_bytes_size) tmp_bytes_size = t2;
   uint8_t* tmp_bytes = get_tmp_space(tmp_bytes_size);  // prealloc
   VEC_ZNX_DFT* col_res = vec_znx_dft_alloc(module, ONIONPIR_query1exp_ncols);
@@ -318,8 +318,7 @@ void onionpir_prgsw_to_rgsw(const MODULE* module, const onionpir_cloud_key& ckey
                                 ONIONPIR_rk_ncols,  //
                                 in_a_size,          //
                                 ONIONPIR_rk_nrows, ONIONPIR_rk_ncols);
-  tb |= vec_znx_big_range_normalize_base2k_tmp_bytes(  //
-      module, out_a_size, ONIONPIR_rk_ncols);
+  tb |= vec_znx_big_range_normalize_base2k_tmp_bytes(module);
   uint8_t* tmp_bytes = get_tmp_space(tb);
 
   for (uint64_t i = 0; i < in_nrows; ++i) {
@@ -376,8 +375,7 @@ void onionpir_cmux_eval(const MODULE* module, int64_t* out_rlwe, uint64_t out_si
                                 Sout,    //
                                 Sin,     //
                                 Sin, Sout);
-  tb |= vec_znx_big_range_normalize_base2k_tmp_bytes(  //
-      module, Sout, Sout);
+  tb |= vec_znx_big_range_normalize_base2k_tmp_bytes(module);
   uint8_t* tmp_bytes = get_tmp_space(tb);
 
   // diff = c1 - c0

--- a/05-onionpir/samples_test_internal.cpp
+++ b/05-onionpir/samples_test_internal.cpp
@@ -31,7 +31,7 @@ TEST(noise, round_polynomial_noise) {
       uint64_t sa = 6;
       uint64_t a_sl = nn + 3;
       // generate a base2k random reduced a
-      std::vector<uint8_t> tmp_space(vec_znx_normalize_base2k_tmp_bytes(module, sa, sa));
+      std::vector<uint8_t> tmp_space(vec_znx_normalize_base2k_tmp_bytes(module));
       znx_vec_i64_layout a(nn, sa, a_sl);
       a.fill_random(50);
       vec_znx_normalize_base2k(module, k, a.data(), sa, a_sl, a.data(), sa, a_sl, tmp_space.data());
@@ -796,7 +796,7 @@ TEST(onionpir, onionpir_trace_expand) {
   std::vector<int64_t> mulmessage = message;
   for (int64_t& x : mulmessage) x *= res_mult_coef;
   vec_znx_normalize_base2k(module.get(), K, mulmessage.data(), mu_size, N, mulmessage.data(), mu_size, N,
-                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module.get(), mu_size, mu_size)));
+                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module.get())));
 
   // call tested function
   std::vector<int64_t> res_rlwes(res_nrows * res_ncols * ONIONPIR_N, 0);

--- a/05-onionpir/tiny_fhe.cpp
+++ b/05-onionpir/tiny_fhe.cpp
@@ -230,7 +230,7 @@ void rlwe_encrypt_base2k(const MODULE* module,                                  
 
   // allocate temporary space for idft and big normalize
   const uint64_t idft_bytes = vec_znx_idft_tmp_bytes(module);
-  const uint64_t norm_bytes = vec_znx_big_normalize_base2k_tmp_bytes(module, new_b_size, res_size);
+  const uint64_t norm_bytes = vec_znx_big_normalize_base2k_tmp_bytes(module);
   uint8_t* tmp = get_tmp_space(idft_bytes > norm_bytes ? idft_bytes : norm_bytes);
 
   // a.s
@@ -264,7 +264,7 @@ void rlwe_phase_base2k(const MODULE* module,                              //
 
   // allocate temporary space for idft and big normalize
   const uint64_t idft_bytes = vec_znx_idft_tmp_bytes(module);
-  const uint64_t norm_bytes = vec_znx_big_normalize_base2k_tmp_bytes(module, phi_size, a_size);
+  const uint64_t norm_bytes = vec_znx_big_normalize_base2k_tmp_bytes(module);
   uint8_t* tmp = get_tmp_space(idft_bytes > norm_bytes ? idft_bytes : norm_bytes);
 
   // a.s
@@ -316,10 +316,10 @@ void rlwe_trace_expand_1step(const MODULE* module,                      //
   const uint64_t b_res1_size = res1_size / 2;
 
   vec_znx_normalize_base2k(module, log2_base2k, res1_rlwe, a_res1_size, 2 * nn, tmp1, a_tmp_size, 2 * nn,
-                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module, a_res1_size, a_tmp_size)));
+                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module)));
 
   vec_znx_normalize_base2k(module, log2_base2k, res1_rlwe + nn, b_res1_size, 2 * nn, tmp1 + nn, b_tmp_size, 2 * nn,
-                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module, b_res1_size, b_tmp_size)));
+                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module)));
 
   // res0 = in + in(X^p)
   vec_znx_add(module, tmp1, tmp_size, nn, in_rlwe, in_size, nn, tmp, tmp_size, nn);
@@ -329,10 +329,10 @@ void rlwe_trace_expand_1step(const MODULE* module,                      //
   const uint64_t b_res0_size = res0_size / 2;
 
   vec_znx_normalize_base2k(module, log2_base2k, res0_rlwe, a_res0_size, 2 * nn, tmp1, a_tmp_size, 2 * nn,
-                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module, a_res0_size, a_tmp_size)));
+                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module)));
 
   vec_znx_normalize_base2k(module, log2_base2k, res0_rlwe + nn, b_res0_size, 2 * nn, tmp1 + nn, b_tmp_size, 2 * nn,
-                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module, b_res0_size, b_tmp_size)));
+                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module)));
 }
 
 void rlwe_trace_expand_1step_no_rotation(const MODULE* module,                      //
@@ -361,8 +361,8 @@ void rlwe_trace_expand_1step_no_rotation(const MODULE* module,                  
   const uint64_t b_res0_size = res0_size / 2;
 
   vec_znx_normalize_base2k(module, log2_base2k, res0_rlwe, a_res0_size, 2 * nn, tmp, a_tmp_size, 2 * nn,
-                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module, a_res0_size, a_tmp_size)));
+                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module)));
 
   vec_znx_normalize_base2k(module, log2_base2k, res0_rlwe + nn, b_res0_size, 2 * nn, tmp + nn, b_tmp_size, 2 * nn,
-                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module, b_res0_size, b_tmp_size)));
+                           get_tmp_space(vec_znx_normalize_base2k_tmp_bytes(module)));
 }


### PR DESCRIPTION
Updated the submodule version for spqlios lib and removed the unnecessary parameters for normalize_base2k_tmp_bytes
